### PR TITLE
Don't accept non-finite float values (+/- inf and NaN)

### DIFF
--- a/bulk_insert.py
+++ b/bulk_insert.py
@@ -298,7 +298,8 @@ def prop_to_binary(prop_val, type):
     if type == None or type == Type.NUMERIC:
         try:
             numeric_prop = float(prop_val)
-            return struct.pack(format_str + "d", Type.NUMERIC, numeric_prop)
+            if not math.isnan(numeric_prop) and not math.isinf(numeric_prop): # Don't accept non-finite values.
+                return struct.pack(format_str + "d", Type.NUMERIC, numeric_prop)
         except:
             pass
 


### PR DESCRIPTION
Explicitly disallow float conversions that result in infinite or NAN values.