### PR TITLE
ID as strings and Parsing array items

### DIFF
--- a/redisgraph_bulk_loader/entity_file.py
+++ b/redisgraph_bulk_loader/entity_file.py
@@ -66,7 +66,7 @@ def typed_prop_to_binary(prop_val, prop_type):
     prop_val = prop_val.strip()
 
     # TODO allow ID type specification
-    if prop_type == Type.ID or prop_type == Type.LONG:
+    if prop_type == Type.LONG:
         try:
             numeric_prop = int(prop_val)
             return struct.pack(format_str + "q", Type.LONG.value, numeric_prop)
@@ -75,7 +75,7 @@ def typed_prop_to_binary(prop_val, prop_type):
             if prop_type == Type.LONG:
                 raise SchemaError("Could not parse '%s' as a long" % prop_val)
 
-    elif prop_type == Type.ID or prop_type == Type.DOUBLE:
+    elif prop_type == Type.DOUBLE:
         try:
             numeric_prop = float(prop_val)
             if not math.isnan(numeric_prop) and not math.isinf(numeric_prop): # Don't accept non-finite values.
@@ -94,7 +94,7 @@ def typed_prop_to_binary(prop_val, prop_type):
         else:
             raise SchemaError("Could not parse '%s' as a boolean" % prop_val)
 
-    elif prop_type == Type.STRING:
+    elif prop_type== Type.ID or  prop_type == Type.STRING:
         # If we've reached this point, the property is a string
         encoded_str = str.encode(prop_val) # struct.pack requires bytes objects as arguments
         # Encoding len+1 adds a null terminator to the string

--- a/redisgraph_bulk_loader/entity_file.py
+++ b/redisgraph_bulk_loader/entity_file.py
@@ -146,7 +146,10 @@ def inferred_prop_to_binary(prop_val):
 
     # If the property string is bracket-interpolated, it is an array.
     if prop_val[0] == '[' and prop_val[-1] == ']':
-        return array_prop_to_binary(format_str, prop_val)
+        try:
+            return array_prop_to_binary(format_str, prop_val)
+        except:
+            pass
 
     # If we've reached this point, the property is a string.
     encoded_str = str.encode(prop_val) # struct.pack requires bytes objects as arguments

--- a/redisgraph_bulk_loader/relation_type.py
+++ b/redisgraph_bulk_loader/relation_type.py
@@ -10,6 +10,8 @@ class RelationType(EntityFile):
     def __init__(self, query_buffer, infile, type_str, config):
         super(RelationType, self).__init__(infile, type_str, config)
         self.query_buffer = query_buffer
+        self.start_namespace = None
+        self.end_namespace = None
 
     def process_schemaless_header(self, header):
         if self.column_count < 2:


### PR DESCRIPTION
There were two issues when I had used bulk loader with enforce schema, 
* The column specified as ID needed to be an Integer,  I tried computing the hash of the string I had  tried to use that as an ID but I was getting errors from Struct suggesting the generated hash value was to long to convert. 
* The second item was when parsing columns specified as Type array , it will try to detect the types of each item in the array. In doing so there are cases where we have items as strings that are not necessarily arrays for instance array that looks like `['selenophosphoric acid','trihydroxidoselenidophosphorus','[P(OH)3Se]']` , so I tried to catch the exception and pass it down 

Please if you have better solutions to my approach I'd be happy to adopt