### PR TITLE
Fix IndexError: strip() before checking for empty value

### DIFF
--- a/redisgraph_bulk_loader/entity_file.py
+++ b/redisgraph_bulk_loader/entity_file.py
@@ -115,13 +115,14 @@ def typed_prop_to_binary(prop_val, prop_type):
 def inferred_prop_to_binary(prop_val):
     # All format strings start with an unsigned char to represent our prop_type enum
     format_str = "=B"
+
+    # Remove leading and trailing whitespace
+    prop_val = prop_val.strip()
+
     if prop_val == "":
         # An empty string indicates a NULL property.
         # TODO This is not allowed in Cypher, consider how to handle it here rather than in-module.
         return struct.pack(format_str, 0)
-
-    # Remove leading and trailing whitespace
-    prop_val = prop_val.strip()
 
     # Try to parse value as an integer.
     try:


### PR DESCRIPTION
I encountered the following error when trying to execute a bulk insert:
```
File "/usr/local/bin/redisgraph-bulk-loader", line 8, in <module>
    sys.exit(bulk_insert())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/redisgraph_bulk_loader/bulk_insert.py", line 118, in bulk_insert
    process_entities(labels)
  File "/usr/local/lib/python3.9/site-packages/redisgraph_bulk_loader/bulk_insert.py", line 31, in process_entities
    entity.process_entities()
  File "/usr/local/lib/python3.9/site-packages/redisgraph_bulk_loader/label.py", line 66, in process_entities
    row_binary = self.pack_props(row)
  File "/usr/local/lib/python3.9/site-packages/redisgraph_bulk_loader/entity_file.py", line 275, in pack_props
    props.append(inferred_prop_to_binary(field))
  File "/usr/local/lib/python3.9/site-packages/redisgraph_bulk_loader/entity_file.py", line 148, in inferred_prop_to_binary
    if prop_val[0] == '[' and prop_val[-1] == ']':
IndexError: string index out of range
```
This happened because:

1. Empty strings are handled first (see [here](https://github.com/RedisGraph/redisgraph-bulk-loader/blob/master/redisgraph_bulk_loader/entity_file.py#L118))
2. Then the property value is stripped (see [here](https://github.com/RedisGraph/redisgraph-bulk-loader/blob/master/redisgraph_bulk_loader/entity_file.py#L124))
3. Then the property value is accessed as if it wasn't empty (see [here](https://github.com/RedisGraph/redisgraph-bulk-loader/blob/master/redisgraph_bulk_loader/entity_file.py#L148))

So in the case where the property value is just a bunch of space tokens, all of those are stripped away in step 2, firing off the IndexError in step 3.

It's quite a simple fix, by just stripping first before checking for the empty string.