### PR TITLE
Add arguments for SSL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,16 @@ python3 redisgraph_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 |  -p   | --port INTEGER             |                                  Redis server port (default: 6379)                                   |
 |  -a   | --password TEXT            |                                Redis server password (default: none)                                 |
 |  -u   | --unix-socket-path TEXT    |                                Redis unix socket path (default: none)                                |
+|  -k   | --ssl-keyfile TEXT         |                                 Path to SSL keyfile (default: none)                                  |
+|  -l   | --ssl-certfile TEXT        |                                 Path to SSL certfile (default: none)                                 |
+|  -m   | --ssl-ca-certs TEXT        |                                 Path to SSL CA certs (default: none)                                 |
 |  -n   | --nodes TEXT               |                      Path to Node CSV file with the filename as the Node Label                       |
 |  -N   | --nodes-with-label TEXT    |                             Node Label followed by path to Node CSV file                             |
 |  -r   | --relations TEXT           |               Path to Relationship CSV file with the filename as the Relationship Type               |
 |  -R   | --relations-with-type TEXT |                     Relationship Type followed by path to relationship CSV file                      |
 |  -o   | --separator CHAR           |                         Field token separator in CSV files (default: comma)                          |
 |  -d   | --enforce-schema           |                 Requires each cell to adhere to the schema defined in the CSV header                 |
-|  -i   | --id-type TEXT             |                The data type of unique node ID properties (either STRING or INTEGER)                 |
+|  -j   | --id-type TEXT             |                The data type of unique node ID properties (either STRING or INTEGER)                 |
 |  -s   | --skip-invalid-nodes       |            Skip nodes that reuse previously defined IDs instead of exiting with an error             |
 |  -e   | --skip-invalid-edges       |            Skip edges that use invalid IDs for endpoints instead of exiting with an error            |
 |  -q   | --quote INT                | The quoting format used in the CSV file. QUOTE_MINIMAL=0,QUOTE_ALL=1,QUOTE_NONNUMERIC=2,QUOTE_NONE=3 |


### PR DESCRIPTION
Add optional `--ssl-keyfile`, `--ssl-certfile`, and `--ssl-ca-certs` arguments to bulk loader. Using any of these flags will require a valid SSL connection for the graph creation to succeed.