### PR TITLE
Add BOOLEAN option for schema column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The accepted data types are:
 |        IGNORE        | This column will not be added to the graph                        |       Optional       |
 |    DOUBLE / FLOAT    | A signed 64-bit floating-point value                              |         Yes          |
 | INT / INTEGER / LONG | A signed 64-bit integer value                                     |         Yes          |
-|         BOOL         | A boolean value indicated by the string 'true' or 'false'         |         Yes          |
+|    BOOL / BOOLEAN    | A boolean value indicated by the string 'true' or 'false'         |         Yes          |
 |        STRING        | A string value                                                    |         Yes          |
 |        ARRAY         | An array value                                                    |         Yes          |
 

--- a/redisgraph_bulk_loader/entity_file.py
+++ b/redisgraph_bulk_loader/entity_file.py
@@ -14,6 +14,7 @@ csv.field_size_limit(sys.maxsize) # Don't limit the size of user input fields.
 class Type(Enum):
     UNKNOWN = 0
     BOOL = 1
+    BOOLEAN = 1     # alias to BOOL
     DOUBLE = 2
     FLOAT = 2       # alias to DOUBLE
     STRING = 3

--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -453,9 +453,9 @@ class TestBulkLoader(unittest.TestCase):
         graphname = "tmpgraph7"
         with open('/tmp/nodes.tmp', mode='w') as csv_file:
             out = csv.writer(csv_file)
-            out.writerow(['str_col:STRING', 'num_col:INT'])
-            out.writerow([0, 0])
-            out.writerow([1, 1])
+            out.writerow(['str_col:STRING', 'num_col:INT', 'bool_col:BOOLEAN'])
+            out.writerow([0, 0, True])
+            out.writerow([1, 1, False])
 
         runner = CliRunner()
         res = runner.invoke(bulk_insert, ['--nodes', '/tmp/nodes.tmp',
@@ -466,9 +466,9 @@ class TestBulkLoader(unittest.TestCase):
         self.assertIn('2 nodes created', res.output)
 
         graph = Graph(graphname, self.redis_con)
-        query_result = graph.query('MATCH (a) RETURN a.str_col, a.num_col ORDER BY a.num_col')
-        expected_result = [['0', 0],
-                           ['1', 1]]
+        query_result = graph.query('MATCH (a) RETURN a.str_col, a.num_col, a.bool_col ORDER BY a.num_col')
+        expected_result = [['0', 0, True],
+                           ['1', 1, False]]
 
         # The graph should have the correct types for all properties
         self.assertEqual(query_result.result_set, expected_result)


### PR DESCRIPTION
`BOOL` and `BOOLEAN` are now interchangeable aliases for schema specification in a CSV file's header row.