### PR TITLE
Tests expect arrays when calling labels()

### DIFF
--- a/test/test_bulk_loader.py
+++ b/test/test_bulk_loader.py
@@ -583,8 +583,8 @@ class TestBulkLoader(unittest.TestCase):
         graph = Graph(graphname, self.redis_con)
         query_result = graph.query('MATCH (src)-[]->(dest) RETURN src.id, src.name, LABELS(src), dest.id, dest.views, LABELS(dest) ORDER BY src.id')
 
-        expected_result = [['0', 'Jeffrey', 'User', '0', 20, 'Post'],
-                           ['1', 'Filipe', 'User', '1', 40, 'Post']]
+        expected_result = [['0', 'Jeffrey', ['User'], '0', 20, ['Post']],
+                           ['1', 'Filipe', ['User'], '1', 40, ['Post']]]
         self.assertEqual(query_result.result_set, expected_result)
 
     def test14_array_properties_inferred(self):
@@ -752,8 +752,8 @@ class TestBulkLoader(unittest.TestCase):
         query_result = graph.query('MATCH (src)-[]->(dest) RETURN src.id, src.name, LABELS(src), dest.id, dest.views, LABELS(dest) ORDER BY src.id')
 
         # The IDs of the results should be parsed as integers
-        expected_result = [[0, 'Jeffrey', 'User', 0, 20, 'Post'],
-                           [1, 'Filipe', 'User', 1, 40, 'Post']]
+        expected_result = [[0, 'Jeffrey', ['User'], 0, 20, ['Post']],
+                           [1, 'Filipe', ['User'], 1, 40, ['Post']]]
         self.assertEqual(query_result.result_set, expected_result)
 
 


### PR DESCRIPTION
Following the introduction of multi-label support in https://github.com/RedisGraph/RedisGraph/pull/1988, the `labels()` function returns an array of strings instead of a string.

This PR updates the tests to expect that.