### PR TITLE
Removing connection options in favour of redis-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,7 @@ python3 redisgraph_bulk_loader/bulk_insert.py GRAPHNAME [OPTIONS]
 
 | Flags | Extended flags             |                                              Parameter                                               |
 |:-----:|----------------------------|:----------------------------------------------------------------------------------------------------:|
-|  -h   | --host TEXT                |                                Redis server host (default: 127.0.0.1)                                |
-|  -p   | --port INTEGER             |                                  Redis server port (default: 6379)                                   |
-|  -a   | --password TEXT            |                                Redis server password (default: none)                                 |
-|  -u   | --unix-socket-path TEXT    |                                Redis unix socket path (default: none)                                |
-|  -k   | --ssl-keyfile TEXT         |                                 Path to SSL keyfile (default: none)                                  |
-|  -l   | --ssl-certfile TEXT        |                                 Path to SSL certfile (default: none)                                 |
-|  -m   | --ssl-ca-certs TEXT        |                                 Path to SSL CA certs (default: none)                                 |
+|  -u   | --redis-url TEXT                |                                Redis url (default: redis://127.0.0.1:6379)                                |
 |  -n   | --nodes TEXT               |                      Path to Node CSV file with the filename as the Node Label                       |
 |  -N   | --nodes-with-label TEXT    |                             Node Label followed by path to Node CSV file                             |
 |  -r   | --relations TEXT           |               Path to Relationship CSV file with the filename as the Relationship Type               |

--- a/redisgraph_bulk_loader/bulk_update.py
+++ b/redisgraph_bulk_loader/bulk_update.py
@@ -129,12 +129,8 @@ class BulkUpdate:
 @click.command()
 @click.argument("graph")
 # Redis server connection settings
-@click.option("--host", "-h", default="127.0.0.1", help="Redis server host")
-@click.option("--port", "-p", default=6379, help="Redis server port")
-@click.option("--password", "-a", default=None, help="Redis server password")
-@click.option("--user", "-w", default=None, help="Username for Redis ACL")
 @click.option(
-    "--unix-socket-path", "-u", default=None, help="Redis server unix socket path"
+    "--redis-url", "-u", default="redis://127.0.0.1:6379", help="Redis connection url"
 )
 # Cypher query options
 @click.option("--query", "-q", help="Query to run on server")
@@ -165,11 +161,7 @@ class BulkUpdate:
 )
 def bulk_update(
     graph,
-    host,
-    port,
-    password,
-    user,
-    unix_socket_path,
+    redis_url,
     query,
     variable_name,
     csv,
@@ -183,22 +175,9 @@ def bulk_update(
     start_time = timer()
 
     # Attempt to connect to Redis server
+    client = redis.from_url(redis_url, decode_responses=True)
     try:
-        if unix_socket_path is not None:
-            client = redis.StrictRedis(
-                unix_socket_path=unix_socket_path,
-                username=user,
-                password=password,
-                decode_responses=True,
-            )
-        else:
-            client = redis.StrictRedis(
-                host=host,
-                port=port,
-                username=user,
-                password=password,
-                decode_responses=True,
-            )
+        client.ping()
     except redis.exceptions.ConnectionError as e:
         print("Could not connect to Redis server.")
         raise e


### PR DESCRIPTION
This is both a breaking change, and a feature. This is a breaking change, because we eliminate command line \(and API\) arguments. This is a feature because we add support for everything in redis \(including these already existing features\), and also bring the same suppotr to the bulk_update command. The two were out of sync.